### PR TITLE
Request to access user account in MetaMask

### DIFF
--- a/src/blockchain/voting/VotingController.js
+++ b/src/blockchain/voting/VotingController.js
@@ -11,6 +11,7 @@ export default class VotingController {
     }
 
     async currentAccount() {
+        await ethereum.enable(); // request access user account (MetaMask)
         const accounts = await this.web3.eth.getAccounts();
         return accounts ? accounts[0] : null;
     }

--- a/src/blockchain/voting/votingContract.js
+++ b/src/blockchain/voting/votingContract.js
@@ -1,5 +1,5 @@
 export default {
-    address: '0xd365939EC4358dA6A1f1894cF2d3806712Eb13b7',
+    address: '0x6e830f974a6deAe12457d74A3d05FC651A8C7D83',
     ABI: [
         {
             "constant": false,

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-const network = 'ropsten';
+const network = 'kovan';
 
 const chainId = (network) => {
     switch(network) {


### PR DESCRIPTION
in order to approve that web3 should be injected into the browser
**must add:**  `await ethereum.enable();`
since it is enabled, this method will not need anymore.

**More info:** 
https://github.com/ethereum/web3.js/issues/2091
https://medium.com/metamask/https-medium-com-metamask-breaking-change-injecting-web3-7722797916a8